### PR TITLE
fix: FileBrowser compilation on Linux and macOS editor

### DIFF
--- a/Runtime/DLLs/Ookii.Dialogs.dll.meta
+++ b/Runtime/DLLs/Ookii.Dialogs.dll.meta
@@ -12,22 +12,58 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      Any: 
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 0
+        Exclude Win64: 0
+  - first:
+      Any:
     second:
       enabled: 1
       settings: {}
   - first:
       Editor: Editor
     second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
       enabled: 0
       settings:
-        DefaultValueInitialized: true
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
   - first:
       Windows Store Apps: WindowsStoreApps
     second:
       enabled: 0
       settings:
         CPU: AnyCPU
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/DLLs/ShellFileDialogs.dll.meta
+++ b/Runtime/DLLs/ShellFileDialogs.dll.meta
@@ -12,22 +12,58 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      Any: 
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 0
+        Exclude Win64: 0
+  - first:
+      Any:
     second:
       enabled: 1
       settings: {}
   - first:
       Editor: Editor
     second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
       enabled: 0
       settings:
-        DefaultValueInitialized: true
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
   - first:
       Windows Store Apps: WindowsStoreApps
     second:
       enabled: 0
       settings:
         CPU: AnyCPU
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/OC.asmdef
+++ b/Runtime/OC.asmdef
@@ -10,7 +10,9 @@
     "includePlatforms": [
         "Editor",
         "WindowsStandalone32",
-        "WindowsStandalone64"
+        "WindowsStandalone64",
+        "LinuxStandalone64",
+        "macOSStandalone"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": true,

--- a/Runtime/Scripts/Data/FileBrowser.cs
+++ b/Runtime/Scripts/Data/FileBrowser.cs
@@ -5,15 +5,17 @@ namespace OC.Data
 {
     public static class FileBrowser
     {
-        private static readonly IFileBrowser Browser;
+        private static readonly IFileBrowser _browser;
         private static string _path;
 
         static FileBrowser() 
         {
-#if UNITY_STANDALONE_WIN
-            Browser = new FileBrowserWindows();
+#if UNITY_STANDALONE_WIN && (UNITY_EDITOR_WIN || !UNITY_EDITOR)
+            _browser = new FileBrowserWindows();
 #elif UNITY_EDITOR
-            Browser = new FileBrowserEditor();
+            _browser = new FileBrowserEditor();
+#else
+            _browser = new FileBrowserNotSupported();
 #endif
         }
 
@@ -26,10 +28,10 @@ namespace OC.Data
         public static string[] OpenFilePanel(string title, string directory, ExtensionFilter[] extensions, bool multiselect)
         {
             if (string.IsNullOrEmpty(directory)) directory = _path;
-            var pathes = Browser.OpenFilePanel(title, directory, extensions, multiselect);
-            if (pathes.Length == 0) return null;
-             _path = pathes[0];
-            return pathes;
+            var path = _browser.OpenFilePanel(title, directory, extensions, multiselect);
+            if (path.Length == 0) return null;
+             _path = path[0];
+            return path;
         }
         
         public static async UniTask<string[]> OpenFilePanelAsync(string title, string directory, string extension, bool multiselect) 
@@ -41,20 +43,20 @@ namespace OC.Data
         public static async UniTask<string[]> OpenFilePanelAsync(string title, string directory, ExtensionFilter[] extensions, bool multiselect)
         {
             if (string.IsNullOrEmpty(directory)) directory = _path;
-            var pathes = await Browser.OpenFilePanelAsync(title, directory, extensions, multiselect);
-            if (pathes.Length == 0) return null;
-            _path = pathes[0];
-            return pathes;
+            var path = await _browser.OpenFilePanelAsync(title, directory, extensions, multiselect);
+            if (path.Length == 0) return null;
+            _path = path[0];
+            return path;
         }
 
         public static string[] OpenFolderPanel(string title, string directory, bool multiselect) 
         {
-            return Browser.OpenFolderPanel(title, directory, multiselect);
+            return _browser.OpenFolderPanel(title, directory, multiselect);
         }
         
         public static async UniTask<string[]> OpenFolderPanelAsync(string title, string directory, bool multiselect, Action<string[]> cb) 
         {
-            return await Browser.OpenFolderPanelAsync(title, directory, multiselect);
+            return await _browser.OpenFolderPanelAsync(title, directory, multiselect);
         }
 
         public static string SaveFilePanel(string title, string directory, string defaultName , string extension) 
@@ -65,7 +67,7 @@ namespace OC.Data
 
         public static string SaveFilePanel(string title, string directory, string defaultName, ExtensionFilter[] extensions) 
         {
-            return Browser.SaveFilePanel(title, directory, defaultName, extensions);
+            return _browser.SaveFilePanel(title, directory, defaultName, extensions);
         }
 
         public static async UniTask<string> SaveFilePanelAsync(string title, string directory, string defaultName, string extension) 
@@ -76,7 +78,7 @@ namespace OC.Data
 
         public static async UniTask<string> SaveFilePanelAsync(string title, string directory, string defaultName, ExtensionFilter[] extensions) 
         {
-            return await Browser.SaveFilePanelAsync(title, directory, defaultName, extensions);
+            return await _browser.SaveFilePanelAsync(title, directory, defaultName, extensions);
         }
     }
 

--- a/Runtime/Scripts/Data/FileBrowserEditor.cs
+++ b/Runtime/Scripts/Data/FileBrowserEditor.cs
@@ -1,8 +1,7 @@
-#if UNITY_EDITOR_WIN
+#if UNITY_EDITOR
 using System;
 using Cysharp.Threading.Tasks;
 using UnityEditor;
-using UnityEngine;
 
 namespace OC.Data
 {
@@ -15,27 +14,29 @@ namespace OC.Data
                 : EditorUtility.OpenFilePanelWithFilters(title, directory, GetFilterFromFileExtensionList(extensions));
             return string.IsNullOrEmpty(path) ? Array.Empty<string>() : new[] { path };
         }
-    
+
         public async UniTask<string[]> OpenFilePanelAsync(string title, string directory, ExtensionFilter[] extensions, bool multiselect)
         {
-            var path = EditorUtility.OpenFilePanelWithFilters(title, directory, GetFilterFromFileExtensionList(extensions));
-            await new WaitUntil(() => !string.IsNullOrEmpty(path));
-            return string.IsNullOrEmpty(path) ? Array.Empty<string>() : new[] { path };
+            var paths = OpenFilePanel(title, directory, extensions, multiselect);
+            // The panel blocks the main thread while it is open. Yield a frame so the caller
+            // resumes on the next player loop tick instead of inside the blocked stack.
+            await UniTask.Yield();
+            return paths;
         }
-    
+
         public string[] OpenFolderPanel(string title, string directory, bool multiselect)
         {
             var path = EditorUtility.OpenFolderPanel(title, directory, "");
             return string.IsNullOrEmpty(path) ? Array.Empty<string>() : new[] { path };
         }
-        
+
         public async UniTask<string[]> OpenFolderPanelAsync(string title, string directory, bool multiselect)
         {
-            var path = EditorUtility.OpenFolderPanel(title, directory, "");
-            await new WaitUntil(() => !string.IsNullOrEmpty(path));
-            return string.IsNullOrEmpty(path) ? Array.Empty<string>() : new[] { path };
+            var paths = OpenFolderPanel(title, directory, multiselect);
+            await UniTask.Yield();
+            return paths;
         }
-    
+
         public string SaveFilePanel(string title, string directory, string defaultName, ExtensionFilter[] extensions)
         {
             var ext = extensions != null ? extensions[0].Extensions[0] : "";
@@ -46,10 +47,10 @@ namespace OC.Data
         public async UniTask<string> SaveFilePanelAsync(string title, string directory, string defaultName, ExtensionFilter[] extensions)
         {
             var path = SaveFilePanel(title, directory, defaultName, extensions);
-            await new WaitUntil(() => !string.IsNullOrEmpty(path));
+            await UniTask.Yield();
             return path;
         }
-    
+
         private static string[] GetFilterFromFileExtensionList(ExtensionFilter[] extensions)
         {
             var filters = new string[extensions.Length * 2];
@@ -58,7 +59,7 @@ namespace OC.Data
                 filters[(i * 2)] = extensions[i].Name;
                 filters[(i * 2) + 1] = string.Join(",", extensions[i].Extensions);
             }
-    
+
             return filters;
         }
     }

--- a/Runtime/Scripts/Data/FileBrowserNotSupported.cs
+++ b/Runtime/Scripts/Data/FileBrowserNotSupported.cs
@@ -1,0 +1,55 @@
+using System;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+namespace OC.Data
+{
+    public class FileBrowserNotSupported : IFileBrowser
+    {
+        private const string TAG = "<b><color=#b78cf9>File Browser</color></b>";
+
+        public string[] OpenFilePanel(string title, string directory, ExtensionFilter[] extensions, bool multiselect)
+        {
+            LogNotSupported(nameof(OpenFilePanel));
+            return Array.Empty<string>();
+        }
+
+#pragma warning disable CS1998
+        public async UniTask<string[]> OpenFilePanelAsync(string title, string directory, ExtensionFilter[] extensions, bool multiselect)
+#pragma warning restore CS1998
+        {
+            return OpenFilePanel(title, directory, extensions, multiselect);
+        }
+
+        public string[] OpenFolderPanel(string title, string directory, bool multiselect)
+        {
+            LogNotSupported(nameof(OpenFolderPanel));
+            return Array.Empty<string>();
+        }
+
+#pragma warning disable CS1998
+        public async UniTask<string[]> OpenFolderPanelAsync(string title, string directory, bool multiselect)
+#pragma warning restore CS1998
+        {
+            return OpenFolderPanel(title, directory, multiselect);
+        }
+
+        public string SaveFilePanel(string title, string directory, string defaultName, ExtensionFilter[] extensions)
+        {
+            LogNotSupported(nameof(SaveFilePanel));
+            return string.Empty;
+        }
+
+#pragma warning disable CS1998
+        public async UniTask<string> SaveFilePanelAsync(string title, string directory, string defaultName, ExtensionFilter[] extensions)
+#pragma warning restore CS1998
+        {
+            return SaveFilePanel(title, directory, defaultName, extensions);
+        }
+
+        private static void LogNotSupported(string method)
+        {
+            Logging.Logger.LogWarning($"{TAG} {method} is not implemented on {Application.platform}");
+        }
+    }
+}

--- a/Runtime/Scripts/Data/FileBrowserNotSupported.cs.meta
+++ b/Runtime/Scripts/Data/FileBrowserNotSupported.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf8485299e848190c69e0bc069445d0d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/Scripts/Data/FileBrowserWindows.cs
+++ b/Runtime/Scripts/Data/FileBrowserWindows.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN && (UNITY_EDITOR_WIN || !UNITY_EDITOR)
 
 using System;
 using System.IO;

--- a/Tests/Editor/Data/TestFileBrowserNotSupported.cs
+++ b/Tests/Editor/Data/TestFileBrowserNotSupported.cs
@@ -1,0 +1,77 @@
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using OC.Data;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace OC.Tests.Editor.Data
+{
+    public class TestFileBrowserNotSupported
+    {
+        private IFileBrowser _fileBrowser;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _fileBrowser = new FileBrowserNotSupported();
+        }
+
+        private static void ExpectNotImplementedWarning(string method)
+        {
+            LogAssert.Expect(LogType.Warning, new Regex($"{method} is not implemented"));
+        }
+
+        [Test]
+        public void OpenFilePanelReturnsEmpty()
+        {
+            ExpectNotImplementedWarning(nameof(IFileBrowser.OpenFilePanel));
+            var paths = _fileBrowser.OpenFilePanel("Title", "", null, false);
+            Assert.That(paths, Is.Not.Null);
+            Assert.That(paths, Is.Empty);
+        }
+
+        [Test]
+        public void OpenFolderPanelReturnsEmpty()
+        {
+            ExpectNotImplementedWarning(nameof(IFileBrowser.OpenFolderPanel));
+            var paths = _fileBrowser.OpenFolderPanel("Title", "", false);
+            Assert.That(paths, Is.Not.Null);
+            Assert.That(paths, Is.Empty);
+        }
+
+        [Test]
+        public void SaveFilePanelReturnsEmpty()
+        {
+            ExpectNotImplementedWarning(nameof(IFileBrowser.SaveFilePanel));
+            var path = _fileBrowser.SaveFilePanel("Title", "", "Name", null);
+            Assert.That(path, Is.Empty);
+        }
+
+        // The async members complete synchronously, so GetResult() also asserts they never hang.
+        [Test]
+        public void OpenFilePanelAsyncReturnsEmpty()
+        {
+            ExpectNotImplementedWarning(nameof(IFileBrowser.OpenFilePanel));
+            var paths = _fileBrowser.OpenFilePanelAsync("Title", "", null, false).GetAwaiter().GetResult();
+            Assert.That(paths, Is.Not.Null);
+            Assert.That(paths, Is.Empty);
+        }
+
+        [Test]
+        public void OpenFolderPanelAsyncReturnsEmpty()
+        {
+            ExpectNotImplementedWarning(nameof(IFileBrowser.OpenFolderPanel));
+            var paths = _fileBrowser.OpenFolderPanelAsync("Title", "", false).GetAwaiter().GetResult();
+            Assert.That(paths, Is.Not.Null);
+            Assert.That(paths, Is.Empty);
+        }
+
+        [Test]
+        public void SaveFilePanelAsyncReturnsEmpty()
+        {
+            ExpectNotImplementedWarning(nameof(IFileBrowser.SaveFilePanel));
+            var path = _fileBrowser.SaveFilePanelAsync("Title", "", "Name", null).GetAwaiter().GetResult();
+            Assert.That(path, Is.Empty);
+        }
+    }
+}

--- a/Tests/Editor/Data/TestFileBrowserNotSupported.cs.meta
+++ b/Tests/Editor/Data/TestFileBrowserNotSupported.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ccdaaf672e8c8f4300ba857eafc89b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/OC.Editor.Tests.asmdef
+++ b/Tests/Editor/OC.Editor.Tests.asmdef
@@ -5,7 +5,8 @@
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:0acc523941302664db1f4e527237feb3",
         "GUID:47fad80190177a94f917a02743203241",
-        "GUID:3b4286cfcf2bfc24395a8d834c659111"
+        "GUID:3b4286cfcf2bfc24395a8d834c659111",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
FileBrowserEditor was guarded with UNITY_EDITOR_WIN while FileBrowser instantiated it under UNITY_EDITOR, so non-Windows editors failed with CS0246. Since UNITY_STANDALONE_WIN is also defined in the editor when the active build target is Windows Standalone, the class was only ever selected in the configurations where it did not compile.

- Guard FileBrowserEditor with UNITY_EDITOR
- Restrict FileBrowserWindows to UNITY_STANDALONE_WIN && (UNITY_EDITOR_WIN || !UNITY_EDITOR) so a Linux or macOS editor targeting Windows Standalone no longer reaches the user32.dll P/Invoke
- Add FileBrowserNotSupported, which logs a warning and returns empty results on platforms without an implementation instead of leaving _browser null
- Allow LinuxStandalone64 and macOSStandalone in OC.asmdef, and limit ShellFileDialogs and Ookii.Dialogs to Editor and Standalone Windows
- Replace WaitUntil with UniTask.Yield in the async panel methods; it kept the frame yield but never completed when the dialog was cancelled
- Add EditMode tests for FileBrowserNotSupported

Closes #111