### PR TITLE
fix: let GuidedPayload sleep on a stopped Transport

### DIFF
--- a/Runtime/Scripts/Components/Transport.cs
+++ b/Runtime/Scripts/Components/Transport.cs
@@ -22,7 +22,7 @@ namespace OC.Components
         public bool IsGuiding => _isGuiding;
         
         [SerializeField]
-        private Actor _actor;
+        protected Actor _actor;
         [SerializeField]
         protected float _width = 0.3f;
         [SerializeField]
@@ -32,11 +32,11 @@ namespace OC.Components
         [SerializeField]
         protected float _factor = 0.001f;
         [SerializeField]
-        private bool _isDynamic; 
+        protected bool _isDynamic; 
         [SerializeField]
-        private bool _isGuiding;
+        protected bool _isGuiding;
         [SerializeField]
-        private bool _gizmos;
+        protected bool _gizmos;
 
         private readonly Property<Vector3> _size = new (new Vector3(0.3f, 0.1f, 1));
         

--- a/Runtime/Scripts/MaterialFlow/GuidedPayload.cs
+++ b/Runtime/Scripts/MaterialFlow/GuidedPayload.cs
@@ -35,18 +35,23 @@ namespace OC.MaterialFlow
         private ControlState _lastState;
         private readonly RaycastHit[] _raycastHits = new RaycastHit[2];
         private readonly List<Transport> _transports = new List<Transport>();
+        
+        private Vector3 _lastAnchor;
+        private bool _isStopped;
 
         private void OnEnable()
         {
             _transform = GetComponent<Transform>();
             _rigidbody = GetComponent<Rigidbody>();
             _payload = GetComponent<Payload>();
-            _payload.ControlState.OnValueChanged += ControlStateChaged;
+            _payload.ControlState.OnValueChanged += ControlStateChanged;
+            _rigidbody.sleepThreshold = 0.01f;
+            _rigidbody.linearDamping  = 0.05f;
         }
 
         private void OnDisable()
         {
-            _payload.ControlState.OnValueChanged -= ControlStateChaged;
+            _payload.ControlState.OnValueChanged -= ControlStateChanged;
         }
 
         private void FixedUpdate()
@@ -79,9 +84,10 @@ namespace OC.MaterialFlow
             if (_joint != null) Destroy(_joint);
             _transports.Clear();
             _transport = null;
+            _isStopped = false;
         }
 
-        private void ControlStateChaged(ControlState state)
+        private void ControlStateChanged(ControlState state)
         {
             if (state != ControlState.Busy) return;
             if (_joint != null) Destroy(_joint);
@@ -149,6 +155,9 @@ namespace OC.MaterialFlow
             _joint.angularYMotion = ConfigurableJointMotion.Locked;
 #endif
             _joint.angularZMotion = ConfigurableJointMotion.Locked;
+            
+            _joint.axis = Quaternion.AngleAxis(_angleOffset, Vector3.up) * Vector3.forward;
+            _isStopped = false;
         }
 
         private void Move()
@@ -156,15 +165,41 @@ namespace OC.MaterialFlow
             if (_joint == null) return;
             if (_transport == null) return;
             
+            var speed = _transport.Value.Value;
             var normal = _transport.GetDirection(_transform.position);
-            _joint.connectedAnchor =  _transport.GetClosetPoint(_transform.position);
-            _rigidbody.transform.rotation = Quaternion.LookRotation(normal, Vector3.up) * Quaternion.AngleAxis(_angleOffset, Vector3.up);
-            _joint.axis = Quaternion.AngleAxis(_angleOffset, Vector3.up) * Vector3.forward;
+            var point = _transport.GetClosetPoint(_transform.position);
+            var rot = Quaternion.LookRotation(normal, Vector3.up) * Quaternion.AngleAxis(_angleOffset, Vector3.up);
+            
+            var stopped = Mathf.Approximately(speed, 0f);
+            
+            if (stopped != _isStopped)
+            {
+                _isStopped = stopped;
+                _joint.xMotion = stopped ? ConfigurableJointMotion.Locked : ConfigurableJointMotion.Free;
+                if (stopped)
+                {
+                    _rigidbody.linearVelocity  = Vector3.zero;
+                    _rigidbody.angularVelocity = Vector3.zero;
+                }
+            }
+
+            if (stopped && _rigidbody.IsSleeping()) return;
+
+            if ((point - _lastAnchor).sqrMagnitude > 1e-6f)
+            {
+                _joint.connectedAnchor = point;
+                _lastAnchor = point;
+            }
+
+            if (Quaternion.Angle(rot, _rigidbody.rotation) > 1e-3f)
+            {
+                _rigidbody.MoveRotation(rot);
+            }
+
 #if UNITY_6000_0_OR_NEWER
-            if (!_rigidbody.isKinematic) _rigidbody.linearVelocity = normal * _transport.Value.Value;
-            _rigidbody.angularVelocity = Vector3.zero;
+            if (!stopped && !_rigidbody.isKinematic) _rigidbody.linearVelocity = normal * _transport.Value.Value;
 #else
-            if (!_rigidbody.isKinematic) _rigidbody.velocity = normal * _transport.Value.Value;
+            if (stopped && !_rigidbody.isKinematic) _rigidbody.velocity = normal * _transport.Value.Value;
 #endif
         }
 


### PR DESCRIPTION
Closes #131 

## Summary

A guided payload resting on a `Transport` surface never went to sleep — not even when the transport speed was `0`. `GuidedPayload.Move()` wrote to the rigidbody (velocity, rotation, joint anchor and axis) on every `FixedUpdate`, which keeps the body permanently awake. Over time the accumulated solver error made the payload jitter and slowly slide in an arbitrary direction.

This PR makes `Move()` idempotent: it only writes to the physics state when something actually changed, and it locks the payload to the surface when the transport is stopped so the rigidbody can fall asleep.

## Changes

### `Runtime/Scripts/MaterialFlow/GuidedPayload.cs`

* **Stopped state handling** — new `_isStopped` flag. On the transition to *stopped* the joint's `xMotion` is switched to `Locked` and linear/angular velocity are zeroed once; on the transition back to *moving* `xMotion` returns to `Free`. This holds the payload in place instead of leaving it free along the transport direction.
* **Early out when asleep** — while stopped and `_rigidbody.IsSleeping()`, `Move()` returns without touching the rigidbody, so it stays asleep.
* **Anchor is only updated when it changes** — `_joint.connectedAnchor` is compared against the cached `_lastAnchor` (`sqrMagnitude > 1e-6f`) before being assigned.
* **Rotation via `MoveRotation`** — the direct `_rigidbody.transform.rotation` assignment (a teleport) is replaced by `_rigidbody.MoveRotation(rot)`, and it is only applied when the angle actually differs (`> 1e-3f`).
* **`_joint.axis` moved to `CreateJoint()`** — it depends only on `_angleOffset`, which is fixed for the lifetime of the joint, so it no longer has to be rewritten every step.
* **Velocity is only written while moving** — `linearVelocity` is no longer assigned when the transport is stopped, and the per-step `angularVelocity = Vector3.zero` write is gone.
* **Sleep tuning** — `sleepThreshold = 0.01f` and `linearDamping = 0.05f` are set in `OnEnable()`, so the body reliably reaches the sleep threshold instead of creeping.
* **`_isStopped` reset** in `CreateJoint()` and `Decouple()` so a re-coupled payload starts from a defined state.
* Typo fix: `ControlStateChaged` → `ControlStateChanged`.

### `Runtime/Scripts/Components/Transport.cs`

* `_actor`, `_isDynamic`, `_isGuiding` and `_gizmos` changed from `private` to `protected`, consistent with the other serialized fields of this abstract class, so derived transport implementations can access them.

## Behaviour after the fix

* A payload on a stopped transport is locked to the surface, goes to sleep and stays quiet — no jitter, no drift.
* It wakes up and follows the surface again as soon as the transport speed becomes non-zero.
* Physics cost of idle payloads on a stopped line drops, because sleeping bodies are no longer simulated.

<img width="771" height="474" alt="image" src="https://github.com/user-attachments/assets/87e57b54-840d-4f49-9eb0-0edc1a43d7a8" />


## Test plan

- [ ] Place several `GuidedPayload`s on a guiding `Transport`, set speed `0`, verify in the Physics Debugger that the rigidbodies go to sleep and the positions stay stable over a few minutes.
- [ ] Set the transport speed to a non-zero value, verify the payloads wake up and move with the correct speed and orientation.
- [ ] Repeatedly start/stop the transport, verify there is no position offset accumulating and no jump on start.
- [ ] Payload transfer between two transports (also with a 90° direction change) still works and the joint is recreated correctly.
- [ ] `Pick`/`Place` (`ControlState.Busy`) and `Decouple()` still release the payload correctly.
- [ ] Existing play mode tests pass.
