### PR TITLE
fix: initialize GripperBase collider references in Awake

### DIFF
--- a/Runtime/Scripts/MaterialFlow/GripperBase.cs
+++ b/Runtime/Scripts/MaterialFlow/GripperBase.cs
@@ -45,6 +45,13 @@ namespace OC.MaterialFlow
         [SerializeField]
         private List<Payload> _buffer = new ();
 
+        private void Awake()
+        {
+            GetReferences();
+            _initColliderSize = _collider.size;
+            _initColliderCenter = _collider.center;
+        }
+
         private new void OnEnable()
         {
             base.OnEnable();
@@ -55,15 +62,8 @@ namespace OC.MaterialFlow
         private new void OnDisable()
         {
             base.OnDisable();
-            _isActive.OnValueChanged += OnIsActiveChanged;
-            _isPicked.OnValueChanged += OnIsPickedChanged;
-        }
-
-        private void Start()
-        {
-            GetReferences();
-            _initColliderSize = _collider.size;
-            _initColliderCenter = _collider.center;
+            _isActive.OnValueChanged -= OnIsActiveChanged;
+            _isPicked.OnValueChanged -= OnIsPickedChanged;
         }
 
         public void Pick(bool pick)
@@ -174,6 +174,7 @@ namespace OC.MaterialFlow
         private void SetColliderSize(bool isGripped)
         {
             if (!_dynamicSize) return;
+            if (_collider == null) return;
 
             if (isGripped)
             {


### PR DESCRIPTION
Closes #133

## Problem

`GripperBase.SetColliderSize` threw a `NullReferenceException` whenever `Pick()` was invoked during the `OnEnable` phase, before `GripperBase.Start()` had cached the `BoxCollider`.

`Property.Subscribe` invokes its handler immediately with the current value, so a `Cylinder` that wires `OnLimitMinEvent` / `OnLimitMaxEvent` to `GripperBase.Pick()` runs the whole pick chain inside `Cylinder.OnEnable()`. Unity guarantees every `OnEnable` runs before any `Start`, so `_collider` was still `null`.

The crash only surfaced with `Dynamic Size` enabled, and only when the gripper's `OnEnable` had already subscribed `OnIsActiveChanged` — component order is not deterministic, which made it intermittent.

## Changes

**`Runtime/Scripts/MaterialFlow/GripperBase.cs`**

1. **`Start()` → `Awake()`** — `GetReferences()` and the `_initColliderSize` / `_initColliderCenter` caching moved to `Awake`, so `_collider` is valid before any component's `OnEnable` can drive `Pick()`. This also moves the `isTrigger` / `isKinematic` / `useGravity` setup ahead of the first `FixedUpdate`.

2. **`OnDisable()` now unsubscribes** — it used `+=` where it should have used `-=`:

   ```csharp
   private new void OnDisable()
   {
       base.OnDisable();
       _isActive.OnValueChanged += OnIsActiveChanged;   // never unsubscribed
       _isPicked.OnValueChanged += OnIsPickedChanged;   // never unsubscribed
   }
   ```

   Handlers accumulated on every disable/enable cycle, so `OnIsActiveChangedEvent` / `OnIsPickedChangedEvent` fired once per past cycle instead of once per state change.

3. **Null guard in `SetColliderSize`** as defense in depth.

## Notes

- No `Awake` exists anywhere in the chain (`MonoComponent` → `Detector` → `GripperBase` → `Gripper` / `GripperFixedJoint`), so the new `Awake` hides nothing, and nothing outside the class called the removed `Start`.
- Minor behavior change: the baseline collider size/center are now sampled in `Awake` rather than `Start`. Any external script that resizes a gripper's `BoxCollider` from its own `Awake`/`OnEnable` would no longer have that folded into the baseline. Nothing in this package does so.

## Verification

- The `OC` runtime assembly compiles cleanly (built out-of-editor with Unity 6.3 Roslyn against the reference set from the generated `OC.csproj`, 0 errors).
- PlayMode `TestGripper` covers pick/place across all payload categories, gripper-to-gripper transfer, and placement into pool/assembly/transport.
